### PR TITLE
new lighting

### DIFF
--- a/Resources/Prototypes/_Leviathan/Entities/Objects/light_tubes.yml
+++ b/Resources/Prototypes/_Leviathan/Entities/Objects/light_tubes.yml
@@ -1,0 +1,24 @@
+- type: entity
+  parent: LightTube
+  id: LeviathanLightTube
+  suffix: Leviathan
+  components:
+  - type: LightBulb
+    bulb: Tube
+    color: "#FFE4CE" # 5000K color temp
+    lightEnergy: 0.5
+    lightRadius: 4.5
+    lightSoftness: 3
+    PowerUse: 25
+
+- type: entity
+  parent: LightBulb
+  id: LeviathanLightBulb
+  suffix: Leviathan
+  components:
+  - type: LightBulb
+    bulb: Bulb
+    color: "#FFD1A3" # 4000K color temp
+    lightEnergy: 0.3
+    lightRadius: 2.5
+    lightSoftness: 3

--- a/Resources/Prototypes/_Leviathan/Entities/Structures/lights.yml
+++ b/Resources/Prototypes/_Leviathan/Entities/Structures/lights.yml
@@ -1,0 +1,31 @@
+- type: entity
+  parent: Poweredlight
+  id: LeviathanPoweredlight
+  suffix: Leviathan
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: LeviathanLightTube
+    damage:
+      types:
+        Heat: 5
+  - type: PointLight
+    radius: 4.5
+    energy: 0.5
+    softness: 3
+    offset: "0, -0.5"
+
+- type: entity
+  parent: PoweredSmallLight
+  id: LeviathanPoweredSmallLight
+  suffix: Leviathan
+  components:
+  - type: PoweredLight
+    hasLampOnSpawn: LeviathanLightBulb
+    damage:
+      types:
+        Heat: 5
+  - type: PointLight
+    radius: 2.5
+    energy: 0.3
+    softness: 3
+    offset: "0, -0.5"


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
new dim lighting to soothe my soul
**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 
(adding clothing, items, new features, etc) must include ingame media or the PR will not be merged, in accordance with our PR guidelines.
This makes it much easier for us to merge PRs and find media for progress reports. If you include media in your pull request, we 
may potentially use it in the SS14 progress reports, with clear credit given.

Use screenshot software like Window's built in snipping tool, ShareX, Lightshot, or recording software like ShareX (gif), ScreenToGif, or Open Broadcaster Software (cross platform).
If you're unsure whether your PR will require media, ask a maintainer.

Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://user-images.githubusercontent.com/98561806/211240086-1a5badd2-274e-4dc8-99dc-19d2594a460b.png)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged
There are 4 icons for changelog entries: add, remove, tweak, fix. I trust you can figure out the rest.

You can put your name after the :cl: symbol to change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB

Generally, only put things in changelogs that players actually care about. Stuff like "Refactored X system, no changes should be visible" shouldn't be on a changelog.

For writing actual entries, don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers
-->

:cl:
- add: new dim lighting

